### PR TITLE
Add loot tables for Darkwood Wood (and Stripped)

### DIFF
--- a/src/main/resources/data/druidcraft/loot_tables/blocks/darkwood_wood.json
+++ b/src/main/resources/data/druidcraft/loot_tables/blocks/darkwood_wood.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "druidcraft:darkwood_wood"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/druidcraft/loot_tables/blocks/stripped_darkwood_wood.json
+++ b/src/main/resources/data/druidcraft/loot_tables/blocks/stripped_darkwood_wood.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "druidcraft:stripped_darkwood_wood"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Loot tables were missing, nothing was dropping from them when harvested.